### PR TITLE
Unregister the shortcut before we call register if it's already registered

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,9 @@ function registerSummonShortcut (app) {
   const { plugins, config } = app;
   function register (accelerator) {
     if (!accelerator) return;
+    if (globalShortcut.isRegistered(accelerator)) {
+      globalShortcut.unregister(accelerator);
+    }
     const registered = globalShortcut.register(accelerator, () => {
       const windows = [...windowSet];
       const focusedWindows = windows.filter(window => window.isFocused());


### PR DESCRIPTION
I think this fixes #3 - @sheerun how does this look to you?