### PR TITLE
Move all shortcut/hotkey registration code to another module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "summon"
   ],
   "author": "John Soutar <john@soutar.me>",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "hyperterm-register-shortcut": "^1.0.1"
+  }
 }


### PR DESCRIPTION
@sheerun @rauchg Feedback from you two would be great on this if you have time. 😄 

I've taken the shortcut registration code from this module and made it available in [hyperterm-register-shortcut](https://github.com/soutar/hyperterm-register-shortcut) so I could create [hyperterm-float](https://github.com/soutar/hyperterm-float) without repeating myself. Do you think this the right approach?