### PR TITLE
Disable hide for fullscreen windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,12 @@ function showWindows (windows, app) {
 }
 
 function hideWindows (windows, app) {
-  windows.forEach(win => win.hide());
-  app.hide(); // Mac OS only (re-focuses the last active app)
+  windows.forEach((win) => {
+    if (!win.isFullScreen()) {
+      win.hide();
+    }
+  });
+  app.hide(); // macOS only (re-focuses the last active app)
 }
 
 function toggleWindowVisibility (app) {


### PR DESCRIPTION
Hiding full-screen windows leaves an empty, dark gray background in its place. This provides little value. It also is a jarring experience, as the window suddenly hides in the middle of sliding out to reveal the previously focused application.

While somewhat related, this does not resolve the inability to focus a previous application that has no currently open windows referenced in #8.