### PR TITLE
Fix clicking macOS dock icon of Hyper after being hidden with hyperterm-summon

### DIFF
--- a/modules/setup.js
+++ b/modules/setup.js
@@ -1,5 +1,6 @@
 const registerShortcut = require('hyperterm-register-shortcut');
 const toggleWindowVisibility = require('./windows').toggleWindowVisibility;
+const showWindows = require('./windows').showWindows;
 
 const DEFAULTS = {
   hideDock: false


### PR DESCRIPTION
Clicking the macOS dock icon of Hyper after being hidden with hyperterm-summon used to throw the following error:
```
A JavaScript error occurred in the main process
Uncaught Exception:
ReferenceError: showWindows is not defined
    at App.app.on (/Users/yn5/.hyper_plugins/local/hyperterm-summon/modules/setup.js:19:5)
    at emitTwo (events.js:111:20)
    at App.emit (events.js:191:7)
```