### PR TITLE
Fix dock errors on Windows

### DIFF
--- a/fixtures/app.js
+++ b/fixtures/app.js
@@ -1,18 +1,20 @@
-exports.generateApp = () => ({
-  config: {
-    getConfig: jest.fn(() => ({})),
-    subscribe: jest.fn()
-  },
-  createWindow: jest.fn(),
-  dock: {
+exports.generateApp = opts => (
+  Object.assign({
+    config: {
+      getConfig: jest.fn(() => ({})),
+      subscribe: jest.fn()
+    },
+    createWindow: jest.fn(),
+    dock: {
+      hide: jest.fn(),
+      show: jest.fn()
+    },
+    getLastFocusedWindow: jest.fn(),
+    getWindows: jest.fn(() => new Set()),
     hide: jest.fn(),
+    listeners: jest.fn(() => []),
+    on: jest.fn(),
+    removeListener: jest.fn(),
     show: jest.fn()
-  },
-  getLastFocusedWindow: jest.fn(),
-  getWindows: jest.fn(() => new Set()),
-  hide: jest.fn(),
-  listeners: jest.fn(() => []),
-  on: jest.fn(),
-  removeListener: jest.fn(),
-  show: jest.fn()
-})
+  }, opts)
+)

--- a/modules/__tests__/app.test.js
+++ b/modules/__tests__/app.test.js
@@ -33,11 +33,7 @@ describe('applyConfig', () => {
 
   describe('with hideDock config enabled', () => {
     beforeEach(() => {
-      app.config.getConfig.mockReturnValue({
-        summon: {
-          hideDock: true
-        }
-      })
+      app.config.getConfig.mockReturnValue({ summon: { hideDock: true } })
       applyConfig(app, handleBlurMock)
     })
 
@@ -79,6 +75,13 @@ describe('applyConfig', () => {
       it('does not add handler', () => {
         expect(app.on).not.toHaveBeenCalledWith('browser-window-blur', handleBlurMock)
       })
+    })
+  })
+
+  describe('when dock is undefined', () => {
+    it('does not throw error', () => {
+      const appMock = generateApp({ dock: undefined })
+      expect(() => applyConfig(appMock, handleBlurMock)).not.toThrow()
     })
   })
 })

--- a/modules/app.js
+++ b/modules/app.js
@@ -13,9 +13,11 @@ const applyConfig = (app, handleBlur) => {
   // TODO: Unregister prior to registering when supported
   registerShortcut('summon', toggle, DEFAULTS.hotkey)(app)
 
-  config.hideDock
-    ? app.dock.hide()
-    : app.dock.show()
+  if (app.dock) {
+    config.hideDock
+      ? app.dock.hide()
+      : app.dock.show()
+  }
 
   if (!config.hideOnBlur) {
     app.removeListener('browser-window-blur', handleBlur)


### PR DESCRIPTION
Prevent method calls on `app.dock` if it does not exist. For instance, the dock is nonexistent on Windows OS. Fixes #31.