### PR TITLE
Fix dock errors in dispose

### DIFF
--- a/modules/__tests__/dispose.test.js
+++ b/modules/__tests__/dispose.test.js
@@ -86,4 +86,11 @@ describe('dispose', () => {
       );
     });
   });
+
+  describe('on unsupported platforms', () => {
+    it('does not show the dock', () => {
+      app.dock = undefined;
+      expect(() => dispose(app)).not.toThrow();
+    });
+  });
 });

--- a/modules/dispose.js
+++ b/modules/dispose.js
@@ -1,11 +1,13 @@
 // const { unregisterShortcut } = require('hyperterm-register-shortcut')
 const { showWindows } = require('./windows');
 
-module.exports = (app, callbacks) => {
+module.exports = (app, callbacks = {}) => {
   const { cfgUnsubscribe, handleActivate, handleBlur } = callbacks;
 
   showWindows(app);
-  app.dock.show();
+  if (app.dock) {
+    app.dock.show();
+  }
   // TODO: Unregister shortcut when supported
   // unregisterShortcut()
 


### PR DESCRIPTION
Prevent method calls on `app.dock` if it is undefined. Fixes #34.