### PR TITLE
Disable dock show on dispose

### DIFF
--- a/modules/__tests__/dispose.test.js
+++ b/modules/__tests__/dispose.test.js
@@ -24,10 +24,6 @@ describe('dispose', () => {
     expect(showWindows).toHaveBeenCalledTimes(1);
   });
 
-  it('shows the dock icon', () => {
-    expect(app.dock.show).toHaveBeenCalledTimes(1);
-  });
-
   it('unsubscribes from config changes', () => {
     expect(cfgUnsubscribeMock).toHaveBeenCalledTimes(1);
   });

--- a/modules/dispose.js
+++ b/modules/dispose.js
@@ -5,9 +5,6 @@ module.exports = (app, callbacks = {}) => {
   const { cfgUnsubscribe, handleActivate, handleBlur } = callbacks;
 
   showWindows(app);
-  if (app.dock) {
-    app.dock.show();
-  }
   // TODO: Unregister shortcut when supported
   // unregisterShortcut()
 


### PR DESCRIPTION
Prevent flash of macOS dock icon during auto-updates. Fixes #36.