### PR TITLE
[fix] Remove Electron dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,5 @@
     "jest": "^20.0.4",
     "lint-staged": "^4.2.3",
     "prettier": "^1.7.4"
-  },
-  "peerDependencies": {
-    "electron": "^1.6.2"
   }
 }


### PR DESCRIPTION
Remove the unnecessary `electron` peer dependency. Fixes #40.