### PR TITLE
fix(Linux): Summons properly on linux

### DIFF
--- a/modules/app.js
+++ b/modules/app.js
@@ -17,7 +17,9 @@ const applyConfig = (app, handleBlur) => {
     config.hideDock ? app.dock.hide() : app.dock.show();
   }
 
-  if (!config.hideOnBlur) {
+  // Linux handles blurs strangely
+  // override hideOnBlur to true here, so summon at least works!
+  if (!config.hideOnBlur && process.platform !== 'linux') {
     app.removeListener('browser-window-blur', handleBlur);
   } else if (!app.listeners('browser-window-blur').includes(handleBlur)) {
     app.on('browser-window-blur', handleBlur);

--- a/modules/toggle.js
+++ b/modules/toggle.js
@@ -1,7 +1,10 @@
 const { hideWindows, showWindows } = require('./windows');
 
 module.exports = app => {
-  const focusedWindows = [...app.getWindows()].filter(w => w.isFocused());
+  // @NOTE: Linux reports blurred windows as focused, so also use isVisible
+  const focusedWindows = [...app.getWindows()].filter(
+    w => w.isFocused() && w.isVisible()
+  );
 
   focusedWindows.length > 0 ? hideWindows(app) : showWindows(app);
 };


### PR DESCRIPTION
Fixes #56, with a caveat - hideOnBlur gets over-ridden to true on linux.

I've spent the past few hours on this, very difficult issue to replicate in dev mode, because the issue doesn't quite occur the same way when running hyper in dev mode.

I've annotated with comments in the code, but some useful things I found in the process:
- If you want to replicate the issue in dev mode, use window.blur() and you'll notice both isFocused and isVisible report as true - which is why summon tries to hide the (already hidden) window.
- I tried hooking into the window focus/blur events with separate functions, and setting a boolean in a singleton, which fixed it in dev, but not on prod! I think for some reason blurring in prod-mode means it just doesn't trigger the shortcut