### PR TITLE
Re-enable hideOnBlur configuration option for Linux

### DIFF
--- a/modules/app.js
+++ b/modules/app.js
@@ -17,9 +17,7 @@ const applyConfig = (app, handleBlur) => {
     config.hideDock ? app.dock.hide() : app.dock.show();
   }
 
-  // Linux handles blurs strangely
-  // override hideOnBlur to true here, so summon at least works!
-  if (!config.hideOnBlur && process.platform !== 'linux') {
+  if (!config.hideOnBlur) {
     app.removeListener('browser-window-blur', handleBlur);
   } else if (!app.listeners('browser-window-blur').includes(handleBlur)) {
     app.on('browser-window-blur', handleBlur);


### PR DESCRIPTION
The `hideOnBlur` configuration option was previously disabled in #59 to resolve #56. From recent testing by the community, disabling the option appears to be unrelated to #56. This change re-enables the `hideOnBlur` option for Linux. 